### PR TITLE
Fix merge_template function and add unit tests

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -60,11 +60,11 @@ impl Storage {
 
     /// Read a configuration template from S3.
     pub async fn read_template(&self, env: &str) -> Result<Value> {
-        let template = self.fetch_object(env).await?;
+        let mut template = self.fetch_object(env).await?;
         if let Some(default_env) = &self.default_template {
             if env != default_env {
-                let mut default_template = self.fetch_object(default_env).await?;
-                merge_templates(&mut default_template, &template)
+                let default_template = self.fetch_object(default_env).await?;
+                merge_templates(&mut template, &default_template)
             }
         }
         Ok(template)

--- a/src/template.rs
+++ b/src/template.rs
@@ -44,20 +44,85 @@ async fn resolve_templated_value(value: &str, secrets: &Secrets) -> Result<Value
 }
 
 /// Merge two raw template objects, remaining aware of unpopulated values.
+///
+/// This does not overwrite data. If a property is present in both the
+/// destination template and the source template, then the destination
+/// template's value will be preserved.
 pub fn merge_templates(dest: &mut Value, src: &Value) {
-    match (dest, src) {
-        (&mut Value::Object(ref mut dest), &Value::Object(ref src)) => {
-            for (key, value) in src {
-                // Remove template mark, otherwise we won't be able to merge correctly and
-                // both keys--templated and not-templated--will exist in the resulting JSON.
-                if let Some(key_raw) = key.strip_prefix(TEMPLATE_MARK) {
-                    dest.remove(key_raw);
-                }
-                merge_templates(dest.entry(key.clone()).or_insert(Value::Null), value);
+    if let (Value::Object(dest), Value::Object(src)) = (dest, src) {
+        for (key, value) in src {
+            let key_raw = key.strip_prefix(TEMPLATE_MARK).unwrap_or(key);
+            if !dest.contains_key(key_raw)
+                && !dest.contains_key(&format!("{TEMPLATE_MARK}{key_raw}"))
+            {
+                // Total replacement: dest does not contain the key.
+                dest.insert(key.clone(), value.clone());
+            } else if key == key_raw && dest.contains_key(key) {
+                // Partial replacement: both contain raw non-templated key,
+                // so we can merge their objects' subkeys.
+                merge_templates(dest.get_mut(key).unwrap(), value);
             }
         }
-        (dest, src) => {
-            *dest = src.clone();
-        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::merge_templates;
+
+    #[test]
+    fn merge_templates_basic() {
+        let mut dest = json!({ "a": "b" });
+        let src = json!({ "c": "d" });
+        merge_templates(&mut dest, &src);
+        assert_eq!(dest, json!({ "a": "b", "c": "d" }));
+    }
+
+    #[test]
+    fn merge_templates_replacement() {
+        let mut dest = json!({
+            "a": "b",
+            "c": {
+                "d": "e",
+            },
+            "f": {
+                "g": "h",
+                "i": [1_i32, 2_i32, 3_i32],
+            },
+        });
+        let src = json!({
+            "a": "x",
+            "c": 123123_i32,
+            "f": {
+                "a": 42_i32,
+                "g": "y",
+                "i": [1_i32, 2_i32, 4_i32],
+                "p": {
+                    "x": "y",
+                },
+            },
+            "z": "hello",
+        });
+        merge_templates(&mut dest, &src);
+        assert_eq!(
+            dest,
+            json!({
+                "a": "b",
+                "c": {
+                    "d": "e",
+                },
+                "f": {
+                    "a": 42_i32,
+                    "g": "h",
+                    "i": [1_i32, 2_i32, 3_i32],
+                    "p": {
+                        "x": "y",
+                    },
+                },
+                "z": "hello",
+            }),
+        );
     }
 }


### PR DESCRIPTION
Now, the merge_template function will only merge object properties that do not already exist in the destination.