### PR TITLE
Return raw, non-merged template from `/t` endpoint

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -188,7 +188,7 @@
         submit.disabled = true;
         try {
           const newValue = editorValue;
-          const resp = await fetch(`/w/${environment}`, {
+          const resp = await fetch(`/t/${environment}`, {
             method: "PUT",
             body: JSON.stringify(newValue),
             headers: { "Content-Type": "application/json" },

--- a/src/server.rs
+++ b/src/server.rs
@@ -43,7 +43,7 @@ async fn get_config_handler(
     Extension(storage): Extension<Storage>,
     Path(env): Path<String>,
 ) -> Result<Json<Value>, StatusCode> {
-    match storage.read_config(&env).await {
+    match storage.load_config(&env).await {
         Ok(value) => Ok(Json(value)),
         Err(err) => {
             warn!(%env, ?err, "problem reading config");
@@ -69,7 +69,7 @@ async fn put_handler(
     Path(env): Path<String>,
     body: Json<Value>,
 ) -> Result<(), StatusCode> {
-    match storage.write(&env, &body).await {
+    match storage.write_template(&env, &body).await {
         Ok(_) => Ok(()),
         Err(err) => {
             error!(?err, "could not put config");

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,7 +5,7 @@
 
 use anyhow::Result;
 use axum::extract::{Extension, Path};
-use axum::routing::{get, put};
+use axum::routing::get;
 use axum::{http::StatusCode, response::Html, Json, Router};
 use serde_json::Value;
 use tracing::{error, warn};
@@ -18,8 +18,7 @@ pub async fn server(bucket: &str, default_template: Option<&str>) -> Result<Rout
 
     Ok(Router::new()
         .route("/", get(|| async { Html(include_str!("index.html")) }))
-        .route("/w/:env", put(put_handler))
-        .route("/t/:env", get(get_template_handler))
+        .route("/t/:env", get(get_template_handler).put(put_handler))
         .route("/c", get(get_all_configs_handler))
         .route("/c/:env", get(get_config_handler))
         .route("/ping", get(|| async { "cadre ok" }))


### PR DESCRIPTION
This makes the `read_template()` and `write_template()` methods actually complement each other.

Previously `read_template()` would populate values from the default template, which means that if you're editing the template and save it again, it would pull in all the missing values and add them to the data. This is very unexpected.

With this change, `GET /t/:env` and `PUT /t/:env` complement each other with standard REST semantics, and the web interface no longer adds extra data to requested template values.