### PR TITLE
Generic storage and thorough integration tests

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use clap::Parser;
 use tracing::info;
 
-use crate::server::server;
+use crate::server::{server, state::State};
 
 /// A simple, self-hosted, high-performance remote configuration service.
 #[derive(Parser, Debug)]
@@ -34,7 +34,8 @@ impl Args {
 }
 
 async fn run_server(port: u16, bucket: &str, default_template: Option<&str>) -> Result<()> {
-    let app = server(bucket, default_template).await?;
+    let state = State::from_env(bucket, default_template).await;
+    let app = server(state);
 
     let addr: SocketAddr = (Ipv6Addr::UNSPECIFIED, port).into();
     info!(?addr, "running cadre");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,12 +1,23 @@
 //! Command-line interface (used by the binary).
 
 use std::net::{Ipv6Addr, SocketAddr};
+use std::path::PathBuf;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
+use aws_config::meta::region::RegionProviderChain;
+use aws_sdk_s3::Client;
+use aws_types::sdk_config::SdkConfig;
 use clap::Parser;
 use tracing::info;
 
-use crate::server::{server, state::State};
+use crate::server::resolver::{AwsSecrets, ResolverChain};
+use crate::server::{server, state::State, storage::Storage};
+
+/// Creates an AWS SDK default config object.
+pub async fn default_aws_config() -> SdkConfig {
+    let region_provider = RegionProviderChain::default_provider();
+    aws_config::from_env().region(region_provider).load().await
+}
 
 /// A simple, self-hosted, high-performance remote configuration service.
 #[derive(Parser, Debug)]
@@ -16,33 +27,44 @@ pub struct Args {
     #[clap(short, long, default_value_t = 7608)]
     port: u16,
 
-    /// S3 bucket to use for storing cadre templated JSON files.
-    #[clap(short, long)]
-    bucket: String,
+    /// S3 bucket to use for persisting template JSON files.
+    #[clap(long)]
+    bucket: Option<String>,
+
+    /// Local directory to use for persisting template JSON files.
+    #[clap(long, parse(from_os_str))]
+    local_dir: Option<PathBuf>,
 
     /// Sets a default templated JSON to be used for other environments
     /// to build upon. Ignored if left empty.
-    #[clap(short, long)]
+    #[clap(long)]
     default_template: Option<String>,
 }
 
 impl Args {
     /// Run the action corresponding to this CLI command.
     pub async fn run(self) -> Result<()> {
-        run_server(self.port, &self.bucket, self.default_template.as_deref()).await
+        let sdk_config = default_aws_config().await;
+
+        let mut chain = ResolverChain::new();
+        chain.add(AwsSecrets::new(&sdk_config));
+
+        let storage = match (&self.bucket, &self.local_dir) {
+            (Some(bucket), None) => Storage::S3(Client::new(&sdk_config), bucket.into()),
+            (None, Some(local_dir)) => Storage::LocalFS(local_dir.into()),
+            _ => bail!("must specify exactly one of --bucket or --local-dir"),
+        };
+
+        let state = State::new(chain, storage, self.default_template.as_deref());
+        let app = server(state);
+
+        let addr: SocketAddr = (Ipv6Addr::UNSPECIFIED, self.port).into();
+        info!(?addr, "running cadre");
+
+        axum::Server::bind(&addr)
+            .serve(app.into_make_service())
+            .await?;
+
+        Ok(())
     }
-}
-
-async fn run_server(port: u16, bucket: &str, default_template: Option<&str>) -> Result<()> {
-    let state = State::from_env(bucket, default_template).await;
-    let app = server(state);
-
-    let addr: SocketAddr = (Ipv6Addr::UNSPECIFIED, port).into();
-    info!(?addr, "running cadre");
-
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
-        .await?;
-
-    Ok(())
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,7 +3,9 @@
 use anyhow::{ensure, Result};
 use hyper::body::Buf;
 use hyper::client::HttpConnector;
+use hyper::header::CONTENT_TYPE;
 use hyper::{Body, Client, Request};
+use serde::de::DeserializeOwned;
 use serde_json::Value;
 
 /// An asynchronous client for the configuration store.
@@ -26,22 +28,25 @@ impl CadreClient {
         }
     }
 
-    async fn get(&self, uri: &str) -> Result<Value> {
-        let req = Request::builder()
-            .method("GET")
-            .uri(uri)
-            .body(Body::empty())?;
-
+    async fn send(&self, req: Request<Body>) -> Result<impl Buf> {
         let resp = self.client.request(req).await?;
 
         // check response status
         let status = resp.status();
-        ensure!(!status.is_server_error(), "server error: {status}");
-        ensure!(status.is_success(), "get request failed: {status}");
+        ensure!(!status.is_server_error(), "cadre server error: {status}");
+        ensure!(status.is_success(), "cadre get request failed: {status}");
 
         // asynchronously aggregate the chunks of the body and create serde json
-        let body = hyper::body::aggregate(resp).await?;
-        Ok(serde_json::from_reader(body.reader())?)
+        Ok(hyper::body::aggregate(resp).await?)
+    }
+
+    async fn get<T: DeserializeOwned>(&self, uri: &str) -> Result<T> {
+        let req = Request::builder()
+            .method("GET")
+            .uri(uri)
+            .body(Body::empty())?;
+        let resp = self.send(req).await?;
+        Ok(serde_json::from_reader(resp.reader())?)
     }
 
     /// Fetch the raw JSON source for a template.
@@ -49,8 +54,24 @@ impl CadreClient {
         self.get(&format!("{}/t/{}", self.origin, env)).await
     }
 
+    /// Write the value for a template.
+    pub async fn write_template(&self, env: &str, template: &Value) -> Result<()> {
+        let req = Request::builder()
+            .method("PUT")
+            .uri(format!("{}/t/{}", self.origin, env))
+            .header(CONTENT_TYPE, "application/json")
+            .body(serde_json::to_string(template)?.into())?;
+        self.send(req).await?;
+        Ok(())
+    }
+
     /// Read a populated configuration with templated and default values.
     pub async fn load_config(&self, env: &str) -> Result<Value> {
         self.get(&format!("{}/c/{}", self.origin, env)).await
+    }
+
+    /// List all available configuration environment names.
+    pub async fn list_configs(&self) -> Result<Vec<String>> {
+        self.get(&format!("{}/c", self.origin)).await
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -14,6 +14,7 @@ use self::state::State;
 
 pub mod resolver;
 pub mod state;
+pub mod storage;
 pub mod template;
 
 /// Web server for handling requests.

--- a/src/server.rs
+++ b/src/server.rs
@@ -22,7 +22,7 @@ pub fn server(state: State) -> Router {
     Router::new()
         .route("/", get(|| async { Html(include_str!("index.html")) }))
         .route("/t/:env", get(get_template_handler).put(put_handler))
-        .route("/c", get(get_all_configs_handler))
+        .route("/c", get(list_configs_handler))
         .route("/c/:env", get(get_config_handler))
         .route("/ping", get(|| async { "cadre ok" }))
         .layer(Extension(state))
@@ -54,10 +54,10 @@ async fn get_config_handler(
     }
 }
 
-async fn get_all_configs_handler(
+async fn list_configs_handler(
     Extension(state): Extension<State>,
 ) -> Result<Json<Vec<String>>, StatusCode> {
-    match state.list_available_configs().await {
+    match state.list_configs().await {
         Ok(value) => Ok(Json(value)),
         Err(err) => {
             warn!(?err, "problem reading all configs");

--- a/src/server/resolver.rs
+++ b/src/server/resolver.rs
@@ -101,10 +101,10 @@ impl Resolver for AwsSecrets {
 }
 
 /// A resolver that simply echos the input as a string, used for testing.
-#[cfg(test)]
+#[doc(hidden)]
 pub struct EchoName;
 
-#[cfg(test)]
+#[doc(hidden)]
 #[async_trait]
 impl Resolver for EchoName {
     fn prefix(&self) -> &'static str {

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -55,7 +55,9 @@ impl State {
     }
 
     /// Return a list of available configuration templates from S3.
-    pub async fn list_available_configs(&self) -> Result<Vec<String>> {
-        self.storage.list().await
+    pub async fn list_configs(&self) -> Result<Vec<String>> {
+        let mut templates = self.storage.list().await?;
+        templates.sort_unstable();
+        Ok(templates)
     }
 }

--- a/src/server/storage.rs
+++ b/src/server/storage.rs
@@ -1,0 +1,126 @@
+//! Pluggable storage persistence backend for templates.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::str;
+
+use anyhow::{Context, Result};
+use parking_lot::Mutex;
+use serde_json::Value;
+use tokio::fs;
+use tracing::info;
+
+/// Storage backend specification.
+#[derive(Debug)]
+pub enum Storage {
+    /// Persist templates to an S3 bucket.
+    S3(aws_sdk_s3::Client, String),
+
+    /// Persist templates to the local file system.
+    LocalFS(PathBuf),
+
+    /// Only store data in-memory.
+    Memory(Mutex<HashMap<String, Value>>),
+}
+
+impl Storage {
+    /// Retrieve a value from storage.
+    #[tracing::instrument]
+    pub(crate) async fn get(&self, env: &str) -> Result<Value> {
+        info!("reading template");
+        match self {
+            Storage::S3(s3, bucket) => {
+                let key = format!("{env}.json");
+                let resp = s3.get_object().bucket(bucket).key(key).send().await?;
+                let data = resp.body.collect().await?;
+                let bytes = data.into_bytes();
+                Ok(serde_json::from_str(str::from_utf8(&bytes)?)?)
+            }
+            Storage::LocalFS(path) => {
+                let path = path.join(format!("{env}.json"));
+                let data = fs::read(&path).await?;
+                Ok(serde_json::from_slice(&data)?)
+            }
+            Storage::Memory(map) => Ok(map.lock().get(env).context("missing template")?.clone()),
+        }
+    }
+
+    /// Set a value in storage.
+    #[tracing::instrument]
+    pub(crate) async fn set(&self, env: &str, value: &Value) -> Result<()> {
+        info!("writing template");
+        match self {
+            Storage::S3(s3, bucket) => {
+                let key = format!("{env}.json");
+                let content = serde_json::to_vec(value)?.into();
+                s3.put_object()
+                    .bucket(bucket)
+                    .key(key)
+                    .body(content)
+                    .send()
+                    .await?;
+            }
+            Storage::LocalFS(path) => {
+                let path = path.join(format!("{env}.json"));
+                let content = serde_json::to_vec(value)?;
+                fs::write(&path, &content).await?;
+            }
+            Storage::Memory(map) => {
+                map.lock().insert(env.into(), value.clone());
+            }
+        }
+        Ok(())
+    }
+
+    /// List all of the templates in storage.
+    #[tracing::instrument]
+    pub(crate) async fn list(&self) -> Result<Vec<String>> {
+        info!("listing templates");
+        match self {
+            Storage::S3(s3, bucket) => {
+                let objects = s3.list_objects_v2().bucket(bucket).send().await?;
+                Ok(objects
+                    .contents()
+                    .unwrap_or_default()
+                    .iter()
+                    .filter_map(|object| Some(object.key()?.strip_suffix(".json")?.to_owned()))
+                    .collect())
+            }
+            Storage::LocalFS(path) => {
+                let mut dir = fs::read_dir(&path).await?;
+                let mut results = Vec::new();
+                while let Some(entry) = dir.next_entry().await? {
+                    if let Some(name) = entry.file_name().to_str() {
+                        if let Some(env) = name.strip_suffix(".json") {
+                            results.push(env.to_owned());
+                        }
+                    }
+                }
+                Ok(results)
+            }
+            Storage::Memory(map) => Ok(map.lock().keys().cloned().collect()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use serde_json::json;
+
+    use super::Storage;
+
+    #[tokio::test]
+    async fn memory_operations() -> Result<()> {
+        let storage = Storage::Memory(Default::default());
+
+        assert!(storage.get("hello").await.is_err());
+        assert!(storage.list().await?.is_empty());
+
+        storage.set("hello", &json!("world")).await?;
+        assert_eq!(storage.get("hello").await?, json!("world"));
+        assert_eq!(storage.list().await?, vec![String::from("hello")]);
+
+        Ok(())
+    }
+}

--- a/src/server/storage.rs
+++ b/src/server/storage.rs
@@ -52,7 +52,7 @@ impl Storage {
         match self {
             Storage::S3(s3, bucket) => {
                 let key = format!("{env}.json");
-                let content = serde_json::to_vec(value)?.into();
+                let content = serde_json::to_vec_pretty(value)?.into();
                 s3.put_object()
                     .bucket(bucket)
                     .key(key)
@@ -62,7 +62,7 @@ impl Storage {
             }
             Storage::LocalFS(path) => {
                 let path = path.join(format!("{env}.json"));
-                let content = serde_json::to_vec(value)?;
+                let content = serde_json::to_vec_pretty(value)?;
                 fs::write(&path, &content).await?;
             }
             Storage::Memory(map) => {

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -1,0 +1,78 @@
+//! Integration tests for the web server.
+
+use std::net::TcpListener;
+
+use anyhow::Result;
+use cadre::server::{
+    resolver::{EchoName, ResolverChain},
+    server,
+    state::State,
+    storage::Storage,
+};
+use cadre::CadreClient;
+use serde_json::json;
+use tokio::task::JoinHandle;
+
+async fn spawn_test_server() -> Result<(CadreClient, JoinHandle<()>)> {
+    let mut chain = ResolverChain::new();
+    chain.add(EchoName);
+    let storage = Storage::Memory(Default::default());
+    let state = State::new(chain, storage, Some("default"));
+
+    let app = server(state);
+
+    let listener = TcpListener::bind("localhost:0")?;
+    let client = CadreClient::new(&format!("http://{}", listener.local_addr()?));
+
+    let handle = tokio::spawn(async move {
+        axum::Server::from_tcp(listener)
+            .unwrap()
+            .serve(app.into_make_service())
+            .await
+            .unwrap();
+    });
+
+    Ok((client, handle))
+}
+
+#[tokio::test]
+async fn simple_operations() -> Result<()> {
+    let (client, _handle) = spawn_test_server().await?;
+
+    assert!(client.list_configs().await?.is_empty());
+    assert!(client.load_config("hello").await.is_err());
+
+    client
+        .write_template("hello", &json!({ "foo": "bar" }))
+        .await?;
+
+    assert!(client.load_config("hello").await.is_err());
+
+    client.write_template("default", &json!({})).await?;
+    assert_eq!(client.load_config("hello").await?, json!({ "foo": "bar" }));
+    assert_eq!(
+        client.list_configs().await?,
+        vec![String::from("default"), String::from("hello")]
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn override_resolvers() -> Result<()> {
+    let (client, _handle) = spawn_test_server().await?;
+
+    client
+        .write_template("default", &json!({ "foo": "bar" }))
+        .await?;
+    client
+        .write_template("hello", &json!({ "*foo": "echo:banana" }))
+        .await?;
+
+    assert_eq!(
+        client.load_config("hello").await?,
+        json!({ "foo": "banana" })
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
### Changes

This change refactors storage into a separate object and allows us to run `cadre` targeting JSON files in a folder of the local file system:

```bash
cadre --local-dir templates/
```

There's also an in-memory storage backend used for integration tests at the public API level (HTTP / CadreClient), which are added here as well. I also added quite a few unit tests for the new modules, and I'm pretty sure they work.

- resolves MOD-272
- resolves MOD-268