### PR TITLE
Fixes Issue When Merging Templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "cadre"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cadre"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Luis Capelo <luiscape@gmail.com>", "Eric Zhang <ekzhang1@gmail.com>"]
 license = "MIT"
 description = "Cadre is a simple, self-hosted, high-performance remote configuration service."

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -47,10 +47,10 @@ impl State {
         if let Some(default_env) = &self.default_template {
             if env != default_env {
                 let default_template = self.read_template(default_env).await?;
+                populate_template(&mut template, &self.chain).await?;
                 merge_templates(&mut template, &default_template)
             }
         }
-        populate_template(&mut template, &self.chain).await?;
         Ok(template)
     }
 


### PR DESCRIPTION
If a default template has a nested key and the top template has a templated base key, then, when merging, the top template key will replace the entire map of the base template. This is not desired as the base template may have certain keys that don't collide and that we want to preserve.

The solution is to populate the templates prior to the merge operation. 