### PR TITLE
Renders Templates Prior to Merging

### DIFF
--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -44,10 +44,11 @@ impl State {
     /// well, if it is provided.
     pub async fn load_config(&self, env: &str) -> Result<Value> {
         let mut template = self.read_template(env).await?;
+        populate_template(&mut template, &self.chain).await?;
         if let Some(default_env) = &self.default_template {
             if env != default_env {
-                let default_template = self.read_template(default_env).await?;
-                populate_template(&mut template, &self.chain).await?;
+                let mut default_template = self.read_template(default_env).await?;
+                populate_template(&mut default_template, &self.chain).await?;
                 merge_templates(&mut template, &default_template)
             }
         }

--- a/src/server/template.rs
+++ b/src/server/template.rs
@@ -68,10 +68,10 @@ mod tests {
     #[tokio::test]
     async fn merge_template_with_populate() {
         let mut chain = ResolverChain::new();
-        chain.add(EchoName);
+        chain.add(EchoJson);
 
         // Templates are merged correctly when base templated keys exist.
-        let mut dest = json!({ "*a": "echo:hello" });
+        let mut dest = json!({ "*a": "echo:\"hello\"" });
         let src = json!({ "c": "d" });
 
         populate_template(&mut dest, &chain).await.unwrap();
@@ -82,7 +82,7 @@ mod tests {
         // event if the latter is templated.
         let mut dest = json!({
             "a": {
-                "*b": "echo:hello"
+                "*b": "echo:\"hello\""
             }
         });
         let src = json!({ "a": {

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -63,15 +63,29 @@ async fn override_resolvers() -> Result<()> {
     let (client, _handle) = spawn_test_server().await?;
 
     client
-        .write_template("default", &json!({ "foo": "bar" }))
+        .write_template(
+            "default",
+            &json!({ "a": {
+            "b": "foo"
+        } }),
+        )
         .await?;
     client
-        .write_template("hello", &json!({ "*foo": "echo:\"banana\"" }))
+        .write_template(
+            "hello",
+            &json!({ "a": {
+            "*b": "echo:banana",
+            "c": "foo"
+        }  }),
+        )
         .await?;
 
     assert_eq!(
         client.load_config("hello").await?,
-        json!({ "foo": "banana" })
+        json!({ "a": {
+            "b": "banana",
+            "c": "foo"
+        } })
     );
 
     Ok(())

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -66,25 +66,20 @@ async fn override_resolvers() -> Result<()> {
         .write_template(
             "default",
             &json!({ "a": {
-            "b": "foo"
+            "b": "foo",
+            "c": "banana"
         } }),
         )
         .await?;
     client
-        .write_template(
-            "hello",
-            &json!({ "a": {
-            "*b": "echo:\"banana\"",
-            "c": "foo"
-        }  }),
-        )
+        .write_template("hello", &json!({ "*a": "echo:{\"b\": \"bar\"}"  }))
         .await?;
 
     assert_eq!(
         client.load_config("hello").await?,
         json!({ "a": {
-            "b": "banana",
-            "c": "foo"
+            "b": "bar",
+            "c": "banana"
         } })
     );
 

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -74,7 +74,7 @@ async fn override_resolvers() -> Result<()> {
         .write_template(
             "hello",
             &json!({ "a": {
-            "*b": "echo:banana",
+            "*b": "echo:\"banana\"",
             "c": "foo"
         }  }),
         )


### PR DESCRIPTION
Allows for the merging algorithm to also consider nested keys for parent keys that contain a template mark. This scenario is now supported:

```rust
let a = json!({
    "*a": "aws:prod/MySecret",
})

let b = json!({
    "a": {
        "c": "foo",
    }
})
```

Where `aws:prod/MySecret` is:

```json
{
    "b": "<SECRET>"
}
```

The resulting JSON after merge will be:

```json
{
    "a":  {
        "b": "<SECRET>",
        "c": "foo",
    }
}
```